### PR TITLE
`expo-jest` should support `EXPO_PUBLIC_` client env vars & `tsconfigPaths`

### DIFF
--- a/app/(tabs)/__tests__/index-test.js
+++ b/app/(tabs)/__tests__/index-test.js
@@ -1,0 +1,9 @@
+import TabOneScreen from "../index";
+import * as React from "react";
+import renderer from "react-test-renderer";
+
+it(`should display the right client env var`, () => {
+  const tree = renderer.create(<TabOneScreen />).toJSON();
+
+  expect(tree.children[0].children).toStrictEqual(["Tab One ", "test2"]);
+});

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1,0 +1,4 @@
+const env = require("@expo/env");
+const path = require("path");
+
+env.load(process.cwd());

--- a/package.json
+++ b/package.json
@@ -10,7 +10,13 @@
     "test": "jest --watchAll"
   },
   "jest": {
-    "preset": "jest-expo"
+    "preset": "jest-expo",
+    "moduleNameMapper": {
+      "@/(.*)": "<rootDir>/$1"
+    },
+    "setupFiles": [
+      "<rootDir>/jest.setup.js"
+    ]
   },
   "dependencies": {
     "@expo/vector-icons": "^13.0.0",


### PR DESCRIPTION
Hi @EvanBacon. 

Building out an app with expo 49, and noticed jest-expo doesn't support `tsconfigPaths` & `EXPO_PUBLIC_` client env vars. It's seemingly pretty trivial to support out of the box ive added am example below, though not sure of the complexity of how to add to expo-jest repo itself. I left a comment on the forum, but thought this might be a better way to bring to your attention. 

Your doing amazing work! 🙌